### PR TITLE
Add md compile instruction in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ Import the `github-markdown.css` file and add a `markdown-body` class to the con
 </article>
 ```
 
+This CSS support most flavours of Markdown, but if you want code syntax highlight use GitHub Flavored Markdown generated from [their `/markdown` API](https://developer.github.com/v3/markdown/).
 
 ## How
 


### PR DESCRIPTION
I had to google around why code syntax didn't work when I was using [marked.js](https://marked.js.org) rendered Markdown. Would be nice to include some instruction for someone like me in the future